### PR TITLE
Update explanation.py (Explaination.as_pyplot_figure)

### DIFF
--- a/lime/explanation.py
+++ b/lime/explanation.py
@@ -150,7 +150,7 @@ class Explanation(object):
         """
         return self.local_exp
 
-    def as_pyplot_figure(self, label=1, figsize=(4,4), **kwargs):
+    def as_pyplot_figure(self, label=1, figsize=(4,4), dpi=100, **kwargs):
         """Returns the explanation as a pyplot figure.
 
         Will throw an error if you don't have matplotlib installed
@@ -160,13 +160,13 @@ class Explanation(object):
                    Will be ignored for regression explanations.
             figsize: desired size of pyplot in tuple format, defaults to (4,4).
             kwargs: keyword arguments, passed to domain_mapper
-
+            dpi: desired DPI(Dots per Inch) of pyplot in integer, default to 100.
         Returns:
             pyplot figure (barchart).
         """
         import matplotlib.pyplot as plt
         exp = self.as_list(label=label, **kwargs)
-        fig = plt.figure(figsize=figsize)
+        fig = plt.figure(figsize=figsize, dpi=dpi)
         vals = [x[1] for x in exp]
         names = [x[0] for x in exp]
         vals.reverse()


### PR DESCRIPTION
Had difficulty in viewing the X and Y axis data labels of pyplot when there were 100+ features, especially in small figsize such as the default (10,10). Increasing the figsize with the same dpi causes loss in quality of the image, hence an option to increase dpi is surely helpful in certain situations (i.e. when the user has a lot of features). 

pyplot.figure() has a parameter called dpi used to control the resolution of the figure, hence access to the dpi parameter would be beneficial for the developers.